### PR TITLE
Fix VID/PID formatting in port picker

### DIFF
--- a/portPicker.html
+++ b/portPicker.html
@@ -48,7 +48,15 @@
 
 <script>
   // formátovací pomocník: dec ➜ 0xABCD
-  const hex = n => n ? '0x' + n.toString(16).toUpperCase().padStart(4,'0') : '-';
+  const hex = n => {
+    if (n === undefined || n === null) return '-';
+    // accept numbers or strings like "2341" or "0x2341"
+    const num = typeof n === 'string'
+                ? parseInt(n.replace(/^0x/i, ''), 16)
+                : n;
+    if (Number.isNaN(num)) return '-';
+    return '0x' + num.toString(16).toUpperCase().padStart(4, '0');
+  };
 
   window.picker.onPorts(ports => {
     const list = document.getElementById('portList');


### PR DESCRIPTION
## Summary
- handle strings like `0x2341` and `2341` when showing VID/PID in `portPicker.html`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883ff929f8c8332839e930ae6caecce