### PR TITLE
Add manual udev setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # ESP-IDE-Electron-desktop-app
 ESP-IDE-Offline-desktop-app
+
+## Manual setup for serial port access
+
+If you install the application manually or run it from sources, configure the
+permissions for serial ports with the following commands:
+
+```bash
+sudo cp 99-espide-serial.rules /etc/udev/rules.d/
+sudo chmod 644 /etc/udev/rules.d/99-espide-serial.rules
+sudo usermod -aG dialout <username>
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+```
+
+These steps are executed automatically by `postinstall.sh` when installing the
+`.deb` package.


### PR DESCRIPTION
## Summary
- document manual serial-port configuration for Linux
- mention that `postinstall.sh` automates these steps for `.deb` packages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6884d07199e48332b07c66dda196e9c7