### PR TITLE
Fix rules path in postinstall

### DIFF
--- a/postinstall.sh
+++ b/postinstall.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 echo "[ESP-IDE] Instalace pravidel pro USB zařízení..."
+SCRIPT_DIR=$(dirname "$0")
 RULES_FILE="/etc/udev/rules.d/99-espide-serial.rules"
 
 # Zkopíruj pravidla (musí se spustit pod sudo z .deb balíčku)
-install -m 644 ./99-espide-serial.rules "$RULES_FILE"
+install -m 644 "$SCRIPT_DIR/99-espide-serial.rules" "$RULES_FILE"
 
 # Přidej uživatele do dialout, pokud ještě není
 if ! groups "$USER" | grep -q dialout; then


### PR DESCRIPTION
## Summary
- resolve script directory in `postinstall.sh`
- copy udev rules from resolved directory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884d0829ac8833291941a25e592aaf5